### PR TITLE
composer naming convention

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Envalo/Widget",
+    "name": "envalo/widget",
     "license": "MIT",
     "type": "magento-module",
     "description": "Enhance Magento Widgets with Specific CMS Page Placement",


### PR DESCRIPTION
make package compatible for packagist.org

errorMsg: The package name Envalo/Widget is invalid, it should not contain uppercase characters. We suggest using envalo/widget instead.
