### PR TITLE
Remove requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,6 @@
     "type": "magento-module",
     "description": "Enhance Magento Widgets with Specific CMS Page Placement",
     "homepage": "https://www.envalo.com",
-    "require": {
-        "magento-hackathon/magento-composer-installer": "2.1.1"
-    },
     "authors":[
         {
             "name":"Tim Reynolds"


### PR DESCRIPTION
The magento-composer-installer should be a requirement of the project installing the modules, not the module itself.